### PR TITLE
Fix line ending to "LF" in "gradlew" so the Docker build works when the repository is checkout in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+gradlew text eol=lf


### PR DESCRIPTION
I struggled with the following error for multiple hours:

![image](https://user-images.githubusercontent.com/13102251/171509533-524821b9-0941-4428-b82a-df11ae9c86b1.png)

The problem was the line ending of the file `gradlew` being `CRLF` instead of `LF` after cloning.
I last encountered it a few years ago, so I forgot this could be a problem. This could prevent someone else wasting so much time on this error.

Note: This might have something to do with the git distribution one is using, since the behavior can also be set globally. I'm using the x64 portable distribution from here, which does not set this behavior: https://git-scm.com/download/win